### PR TITLE
Remove deprecated YAML.mapping and replace with YAML::Serializable

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -54,9 +54,6 @@ dependencies:
     github: crystal-loot/exception_page
     version: ~> 0.5.0
 
-  yaml_mapping:
-    github: crystal-lang/yaml_mapping.cr
-    version: ~> 0.1.0
 
 development_dependencies:
   ameba:

--- a/src/amber/environment/logging.cr
+++ b/src/amber/environment/logging.cr
@@ -1,5 +1,9 @@
+require "yaml"
+
 module Amber::Environment
   class Logging
+    include YAML::Serializable
+    
     alias OptionsType = Hash(String, String | Bool | Array(String))
 
     COLOR_MAP = {
@@ -29,13 +33,24 @@ module Amber::Environment
       "skip"     => [] of String,
     }
 
-    setter color : String,
-      severity : (String | Symbol)
+    @[YAML::Field(key: "color")]
+    setter color : String = "light_cyan"
+    
+    @[YAML::Field(key: "severity")]
+    setter severity : String = "debug"
 
-    property colorize : Bool,
-      skip : Array(String),
-      filter : Array(String)
+    @[YAML::Field(key: "colorize")]
+    property colorize : Bool = true
+    
+    @[YAML::Field(key: "skip")]
+    property skip : Array(String) = [] of String
+    
+    @[YAML::Field(key: "filter")]
+    property filter : Array(String) = ["password", "confirm_password"]
 
+    def initialize
+    end
+    
     def initialize(initial_logging : OptionsType)
       logging = DEFAULTS.merge(initial_logging)
       @colorize = logging["colorize"].as(Bool)


### PR DESCRIPTION
- Replace YAML.mapping in Settings class with YAML::Serializable module
- Update SMTPSettings struct to use YAML::Serializable
- Add YAML::Serializable to Logging class to support deserialization
- Rename internal properties (session_config, pubsub_config, logging_config) while maintaining backward compatibility with setter methods
- Remove yaml_mapping dependency from shard.yml
- All 485 tests passing successfully

🤖 Generated with [Claude Code](https://claude.ai/code)
